### PR TITLE
Add in support for interpolate 

### DIFF
--- a/src/d3ColorInterpolators.js
+++ b/src/d3ColorInterpolators.js
@@ -1,0 +1,41 @@
+import * as d3Scale from 'd3-scale';
+import * as d3ScaleChromatic from 'd3-scale-chromatic';
+
+const scaleKeys = Object.keys(d3Scale).concat(Object.keys(d3ScaleChromatic));
+
+/**
+ * Function that lists available interpolators
+ */
+export default function d3ColorInterpolators() {
+  const list = [
+    'interpolateViridis', 'interpolateInferno', 'interpolateMagma', 'interpolatePlasma',
+    'interpolateWarm', 'interpolateCool', 'interpolateRainbow',
+    'interpolateCubehelixDefault', 'interpolateBrBG', 'interpolatePRGn',
+    'interpolatePiYG', 'interpolatePuOr', 'interpolateRdBu', 'interpolateRdGy',
+    'interpolateRdYlBu', 'interpolateRdYlGn', 'interpolateSpectral',
+    'interpolateBlues', 'interpolateGreens', 'interpolateGreys', 'interpolateOranges',
+    'interpolatePurples', 'interpolateReds', 'interpolateBuGn', 'interpolateBuPu',
+    'interpolateGnBu', 'interpolateOrRd', 'interpolatePuBuGn', 'interpolatePuBu',
+    'interpolatePuRd', 'interpolateRdPu', 'interpolateYlGnBu', 'interpolateYlGn',
+    'interpolateYlOrBr', 'interpolateYlOrRd'];
+
+  // filter only those available in case d3-scale-chromatic not there
+  return list.filter(name => scaleKeys.includes(name));
+}
+
+
+/**
+ * Takes an color interpolator function and returns its string name
+ * @param {Function} interpolator e.g. d3.interpolateWarm
+ * @return {String} The name e.g. "interpolateWarm"
+ */
+export function asString(interpolator) {
+  const list = d3ColorInterpolators();
+  for (let i = 0; i < list.length; i++) {
+    if (d3Scale[list[i]] === interpolator || d3ScaleChromatic[list[i]] === interpolator) {
+      return list[i];
+    }
+  }
+
+  return undefined;
+}

--- a/src/d3ColorSchemes.js
+++ b/src/d3ColorSchemes.js
@@ -25,3 +25,24 @@ export default function d3ColorSchemes() {
   // filter only those available in case d3-scale-chromatic not there
   return list.filter(name => scaleKeys.includes(name));
 }
+
+
+/**
+ * Takes an color scheme function and returns its string name
+ * @param {Function} scheme e.g. d3.schemeAccent
+ * @return {String} The name e.g. "schemeAccent"
+ */
+export function asString(scheme) {
+  const list = d3ColorSchemes();
+
+  // lazy shallow equals with stringify
+  const schemeString = JSON.stringify(scheme);
+
+  for (let i = 0; i < list.length; i++) {
+    if (JSON.stringify(d3Scale[list[i]]) === schemeString || JSON.stringify(d3ScaleChromatic[list[i]]) === schemeString) {
+      return list[i];
+    }
+  }
+
+  return undefined;
+}

--- a/src/d3Interpolators.js
+++ b/src/d3Interpolators.js
@@ -1,24 +1,42 @@
-import * as d3Scale from 'd3-scale';
-import * as d3ScaleChromatic from 'd3-scale-chromatic';
+import * as d3Interpolate from 'd3-interpolate';
 
-const scaleKeys = Object.keys(d3Scale).concat(Object.keys(d3ScaleChromatic));
+const list = [
+  'interpolate',
+  'interpolateNumber',
+  'interpolateRound',
+  'interpolateString',
+  'interpolateDate',
+  'interpolateArray',
+  'interpolateObject',
+  'interpolateRgb',
+  'interpolateHsl',
+  'interpolateHslLong',
+  'interpolateLab',
+  'interpolateHcl',
+  'interpolateHclLong',
+  'interpolateCubehelix',
+  'interpolateCubehelixLong',
+];
 
 /**
- * Function that lists available interpolators
+ * Function that lists available interpolators from d3-interpolate
+ * Use a function just to match the other ones (e.g. d3ColorInterpolators)
  */
 export default function d3Interpolators() {
-  const list = [
-    'interpolateViridis', 'interpolateInferno', 'interpolateMagma', 'interpolatePlasma',
-    'interpolateWarm', 'interpolateCool', 'interpolateRainbow',
-    'interpolateCubehelixDefault', 'interpolateBrBG', 'interpolatePRGn',
-    'interpolatePiYG', 'interpolatePuOr', 'interpolateRdBu', 'interpolateRdGy',
-    'interpolateRdYlBu', 'interpolateRdYlGn', 'interpolateSpectral',
-    'interpolateBlues', 'interpolateGreens', 'interpolateGreys', 'interpolateOranges',
-    'interpolatePurples', 'interpolateReds', 'interpolateBuGn', 'interpolateBuPu',
-    'interpolateGnBu', 'interpolateOrRd', 'interpolatePuBuGn', 'interpolatePuBu',
-    'interpolatePuRd', 'interpolateRdPu', 'interpolateYlGnBu', 'interpolateYlGn',
-    'interpolateYlOrBr', 'interpolateYlOrRd'];
+  return list;
+}
 
-  // filter only those available in case d3-scale-chromatic not there
-  return list.filter(name => scaleKeys.includes(name));
+/**
+ * Takes an interpolator function and returns its string name
+ * @param {Function} interpolator e.g. d3.interpolateNumber
+ * @return {String} The name e.g. "interpolateNumber"
+ */
+export function asString(interpolator) {
+  for (let i = 0; i < list.length; i++) {
+    if (d3Interpolate[list[i]] === interpolator) {
+      return list[i];
+    }
+  }
+
+  return undefined;
 }

--- a/src/ui/ColorSchemeSelector.js
+++ b/src/ui/ColorSchemeSelector.js
@@ -1,6 +1,6 @@
 import { select } from 'd3-selection';
 import { className } from './utils';
-import d3ColorSchemes from '../d3ColorSchemes';
+import d3ColorSchemes, { asString } from '../d3ColorSchemes';
 
 export default class ColorSchemeSelector {
   constructor(parent, props) {
@@ -45,6 +45,6 @@ export default class ColorSchemeSelector {
       this.setup();
     }
 
-    this.select.property('value', this.props.scheme);
+    this.select.property('value', asString(this.props.scheme));
   }
 }

--- a/src/ui/InterpolateSelector.js
+++ b/src/ui/InterpolateSelector.js
@@ -1,8 +1,9 @@
 import { select } from 'd3-selection';
+import * as d3Interpolate from 'd3-interpolate';
 import { className } from './utils';
-import d3ColorInterpolators, { asString } from '../d3ColorInterpolators';
+import d3Interpolators, { asString } from '../d3Interpolators';
 
-export default class InterpolatorSelector {
+export default class InterpolateSelector {
   constructor(parent, props) {
     this.parent = parent;
     this.update(props);
@@ -18,22 +19,22 @@ export default class InterpolatorSelector {
     // create the main panel div
     this.root = select(this.parent)
       .append('div')
-        .attr('class', className('interpolator-selector'));
+        .attr('class', className('interpolate-selector'));
 
     this.select = this.root.append('select')
-      .property('selected', this.props.interpolator)
+      .property('selected', this.props.value)
       .on('change', function change() {
         const value = this.value;
         if (value !== 'null') {
-          that.props.onChange(value);
+          that.props.onChange(d3Interpolate[value]);
         }
       });
 
     this.select.append('option')
       .property('value', 'null')
-      .text('Interpolator');
+      .text('Interpolate');
 
-    d3ColorInterpolators().forEach(interpolator => {
+    d3Interpolators().forEach(interpolator => {
       this.select.append('option')
         .property('value', interpolator)
         .text(interpolator);
@@ -45,6 +46,6 @@ export default class InterpolatorSelector {
       this.setup();
     }
 
-    this.select.property('value', asString(this.props.interpolator));
+    this.select.property('value', asString(this.props.value));
   }
 }

--- a/src/ui/InterpolatorInput.js
+++ b/src/ui/InterpolatorInput.js
@@ -43,7 +43,7 @@ export default class InterpolatorInput {
   renderInterpolatorSelector() {
     this.interpolatorSelector = renderComponent(this.interpolatorSelector, InterpolatorSelector,
       this.root.node(), {
-        interpolator: null,
+        interpolator: this.props.interpolator,
         onChange: this.handleInterpolatorChange,
       });
   }

--- a/src/ui/RangeInput.js
+++ b/src/ui/RangeInput.js
@@ -107,7 +107,7 @@ export default class RangeInput {
     if (this.isColorRange()) {
       this.colorSchemeSelector = renderComponent(this.colorSchemeSelector, ColorSchemeSelector,
         this.inner.node(), {
-          scheme: null,
+          scheme: this.props.range,
           onChange: this.handleColorSchemeChange,
         });
     } else if (this.colorSchemeSelector) {

--- a/src/ui/ScalePanel.js
+++ b/src/ui/ScalePanel.js
@@ -4,6 +4,7 @@ import TypeSelector from './TypeSelector';
 import DomainInput from './DomainInput';
 import RangeInput from './RangeInput';
 import InterpolatorInput from './InterpolatorInput';
+import InterpolateSelector from './InterpolateSelector';
 import BooleanInput from './BooleanInput';
 import NumberInput from './NumberInput';
 
@@ -23,6 +24,7 @@ export default class ScalePanel {
     this.handleClampChange = this.handleScalePropertyChange.bind(this, 'clamp');
     this.handleExponentChange = this.handleScalePropertyChange.bind(this, 'exponent');
     this.handleBaseChange = this.handleScalePropertyChange.bind(this, 'base');
+    this.handleInterpolateChange = this.handleScalePropertyChange.bind(this, 'interpolate');
     this.handleRoundChange = this.handleScalePropertyChange.bind(this, 'round');
     this.handlePaddingChange = this.handleScalePropertyChange.bind(this, 'padding');
     this.handlePaddingInnerChange = this.handleScalePropertyChange.bind(this, 'paddingInner');
@@ -38,6 +40,7 @@ export default class ScalePanel {
     this.renderClampInput = this.renderClampInput.bind(this);
     this.renderExponentInput = this.renderExponentInput.bind(this);
     this.renderBaseInput = this.renderBaseInput.bind(this);
+    this.renderInterpolateInput = this.renderInterpolateInput.bind(this);
     this.renderRoundInput = this.renderRoundInput.bind(this);
     this.renderPaddingInput = this.renderPaddingInput.bind(this);
     this.renderPaddingInnerInput = this.renderPaddingInnerInput.bind(this);
@@ -192,6 +195,12 @@ export default class ScalePanel {
     });
   }
 
+  renderInterpolateInput(parentNode) {
+    this.interpolateInput = renderComponent(this.interpolateInput, InterpolateSelector, parentNode, {
+      value: this.scaleProxy.proxyScale.interpolate(),
+      onChange: this.handleInterpolateChange,
+    });
+  }
 
   renderRoundInput(parentNode) {
     this.roundInput = renderComponent(this.roundInput, BooleanInput, parentNode, {
@@ -253,6 +262,8 @@ export default class ScalePanel {
     this.renderItem('Clamp', this.renderClampInput, 'clamp', 'clampInput');
     this.renderItem('Exponent', this.renderExponentInput, 'exponent', 'exponentInput');
     this.renderItem('Base', this.renderBaseInput, 'base', 'baseInput');
+    this.renderItem('Interpolate', this.renderInterpolateInput, 'interpolate', 'interpolateInput');
+
     this.renderItem('Round', this.renderRoundInput, 'round', 'roundInput');
     this.renderItem('Padding Inner', this.renderPaddingInnerInput, 'paddingInner', 'paddingInnerInput');
     this.renderItem('Padding Outer', this.renderPaddingOuterInput, 'paddingOuter', 'paddingOuterInput');


### PR DESCRIPTION
- Resolves #26 by adding in support for `.interpolate()`
- Adds in support for showing the currently selected interpolator, color interpolator, color scheme
- Simplifies code generation by using helper `asString`
